### PR TITLE
fix: allow run workflow with the same values

### DIFF
--- a/server/src/main/java/org/diskproject/server/repository/DiskRepository.java
+++ b/server/src/main/java/org/diskproject/server/repository/DiskRepository.java
@@ -1313,25 +1313,6 @@ public class DiskRepository extends WriteKBRepository {
             // for-loop handles that
             for (Map<String, String> values : matchingBindings.get(loi)) {
 
-                // DO NO RUN WORKFLOWS WITH THE SAME VALUES
-                Set<String> usedValues = new HashSet<String>();
-                Boolean allDifferent = true;
-                for (String varName : values.keySet()) {
-                    String varValue = values.get(varName);
-                    if (usedValues.contains(varValue)) {
-                        allDifferent = false;
-                        break;
-                    }
-                    usedValues.add(varValue);
-                }
-                if (!allDifferent)
-                    continue;
-                // else {
-                // for (String varName: values.keySet()) {
-                // System.out.println(" + " + varName + ": " + values.get(varName));
-                // }
-                // }
-
                 // Creating query
                 String dq = getQueryBindings(loi.getDataQuery(), varPattern, values);
                 String query = this.getAllPrefixes() + "SELECT DISTINCT ";


### PR DESCRIPTION
We might run a workflow with the same values.

For example
start_month: 1, end_month: 1
fertilizate_rate: 1.0, nitrogeon_rate: 1.0